### PR TITLE
Add Next Schedule device and improve readability

### DIFF
--- a/Husqvarna.py
+++ b/Husqvarna.py
@@ -1,496 +1,942 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
-Python module to get information from Husqvarna Mower.
+Husqvarna API Module
 
-Based on the Husqvarna official API.
-https://developer.husqvarnagroup.cloud/applications
+This module provides a Python interface to the Husqvarna Automower API, allowing control
+and monitoring of Husqvarna robotic lawn mowers. It handles authentication, API requests,
+rate limiting, and various mower operations.
 
+Based on the official Husqvarna API:
+https://developer.husqvarnagroup.cloud/
+
+Author: Filip Demaertelaere
+Version: 2.0.0
 """
 
+import time
+import httpx
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional, Any, Union, Tuple, cast
+from enum import Enum
+from dataclasses import dataclass, field
+import json
+
+# Configure logging based on environment
 try:
     import DomoticzEx as Domoticz
-    def log(msg=""):
-        # Check length to avoid Domoticz debug log limits
-        if len('{}'.format(msg)) <= 5000:
-            Domoticz.Debug(">> {}".format(msg))
+    
+    def log(msg: str = "") -> None:
+        """Log to Domoticz debug log with length management."""
+        formatted = f"{msg}"
+        if len(formatted) <= 5000:
+            Domoticz.Debug(f">> {formatted}")
         else:
             Domoticz.Debug(">> (in several blocks)")
-            # Split message into smaller chunks
-            string = [msg[i:i+5000] for i in range(0, len('{}'.format(msg)), 5000)]
-            for k in string:
-                Domoticz.Debug(">> {}".format(k))
-except:
-    # Fallback log function if DomoticzEx is not available
-    def log(msg=""):
+            # Split message into smaller chunks for Domoticz log limit
+            chunks = [formatted[i:i+5000] for i in range(0, len(formatted), 5000)]
+            for chunk in chunks:
+                Domoticz.Debug(f">> {chunk}")
+except ImportError:
+    # Fallback log function if Domoticz modules aren't available
+    def log(msg: str = "") -> None:
+        """Simple print-based logging for non-Domoticz environments."""
         print(msg)
 
-import httpx
-import time
-from datetime import datetime, timedelta
+class ApiEndpoints:
+    """API endpoints for Husqvarna cloud services."""
+    TOKEN_REQUEST = 'https://api.authentication.husqvarnagroup.dev/v1/oauth2/token'
+    BASE_API = 'https://api.amc.husqvarna.dev/v1/'
+    MOWERS = f'{BASE_API}mowers'
 
-URL_TOKEN_REQUEST = 'https://api.authentication.husqvarnagroup.dev/v1/oauth2/token'
-URL_BASE_API = 'https://api.amc.husqvarna.dev/v1/'
-URL_GET_MOWERS = f'{URL_BASE_API}mowers'
-API_CALL_DELAY = 2
-API_TIMEOUT = 5 #seconds (timeout is for connect and read by default in httpx when given as a single number)
+class ApiConfig:
+    """Configuration values for API communication."""
+    RETRY_DELAY = 2             # Seconds between API calls for retries
+    TIMEOUT = 5                 # Seconds for connection and read timeout
+    TOKEN_REFRESH_MARGIN = 600  # Seconds before token expiration to refresh
 
-ACTION_PARKNEXTSCHEDULE = 'ParkUntilNextSchedule'
-ACTION_PARKFURTHERNOTICE = 'ParkUntilFurtherNotice'
-ACTION_RESUMESCHEDULE = 'ResumeSchedule'
-ACTION_START = 'Start'
-ACTION_PAUSE = 'Pause'
+class HttpMethod(Enum):
+    """HTTP methods used for API requests."""
+    POST = 0
+    GET = 1
 
-STATE_OFF = 'OFF'
+class MowerAction(str, Enum):
+    """Actions that can be sent to the mower."""
+    PARK_NEXT_SCHEDULE = 'ParkUntilNextSchedule'
+    PARK_FURTHER_NOTICE = 'ParkUntilFurtherNotice'
+    RESUME_SCHEDULE = 'ResumeSchedule'
+    START = 'Start'
+    PAUSE = 'Pause'
 
-POST = 0
-GET = 1
+class MowerState(str, Enum):
+    """Possible states of the mower."""
+    OFF = 'OFF'
+    OK = 'OK'
+    ERROR = 'ERROR'
+    WARNING = 'WARNING'
 
-# Error codes dictionary remains the same
-ErrorCodes = {
-    0:    'Unexpected error',
-    1:    'Outside working area',
-    2:    'No loop signal',
-    3:    'Wrong loop signal',
-    4:    'Loop sensor problem, front',
-    5:    'Loop sensor problem, rear',
-    6:    'Loop sensor problem, left',
-    7:    'Loop sensor problem, right',
-    8:    'Wrong PIN code',
-    9:    'Trapped',
-    10:   'Upside down',
-    11:   'Low battery',
-    12:   'Empty battery',
-    13:   'No drive',
-    14:   'Mower lifted',
-    15:   'Lifted',
-    16:   'Stuck in charging station',
-    17:   'Charging station blocked',
-    18:   'Collision sensor problem, rear',
-    19:   'Collision sensor problem, front',
-    20:   'Wheel motor blocked, right',
-    21:   'Wheel motor blocked, left',
-    22:   'Wheel drive problem, right',
-    23:   'Wheel drive problem, left',
-    24:   'Cutting system blocked',
-    25:   'Cutting system blocked',
-    26:   'Invalid sub-device combination',
-    27:   'Settings restored',
-    28:   'Memory circuit problem',
-    29:   'Slope too steep',
-    30:   'Charging system problem',
-    31:   'STOP button problem',
-    32:   'Tilt sensor problem',
-    33:   'Mower tilted',
-    34:   'Cutting stopped - slope too steep',
-    35:   'Wheel motor overloaded, right',
-    36:   'Wheel motor overloaded, left',
-    37:   'Charging current too high',
-    38:   'Electronic problem',
-    39:   'Cutting motor problem',
-    40:   'Limited cutting height range',
-    41:   'Unexpected cutting height adj',
-    42:   'Limited cutting height range',
-    43:   'Cutting height problem, drive',
-    44:   'Cutting height problem, curr',
-    45:   'Cutting height problem, dir',
-    46:   'Cutting height blocked',
-    47:   'Cutting height problem',
-    48:   'No response from charger',
-    49:   'Ultrasonic problem',
-    50:   'Guide 1 not found',
-    51:   'Guide 2 not found',
-    52:   'Guide 3 not found',
-    53:   'GPS navigation problem',
-    54:   'Weak GPS signal',
-    55:   'Difficult finding home',
-    56:   'Guide calibration accomplished',
-    57:   'Guide calibration failed',
-    58:   'Temporary battery problem',
-    59:   'Temporary battery problem',
-    60:   'Temporary battery problem',
-    61:   'Temporary battery problem',
-    62:   'Temporary battery problem',
-    63:   'Temporary battery problem',
-    64:   'Temporary battery problem',
-    65:   'Temporary battery problem',
-    66:   'Battery problem',
-    67:   'Battery problem',
-    68:   'Temporary battery problem',
-    69:   'Alarm! Mower switched off',
-    70:   'Alarm! Mower stopped',
-    71:   'Alarm! Mower lifted',
-    72:   'Alarm! Mower tilted',
-    73:   'Alarm! Mower in motion',
-    74:   'Alarm! Outside geofence',
-    75:   'Connection changed',
-    76:   'Connection NOT changed',
-    77:   'Com board not available',
-    78:   'Slipped - Mower has Slipped.Situation not solved with moving pattern',
-    79:   'Invalid battery combination - Invalid combination of different battery types.',
-    80:   'Cutting system imbalance  Warning',
-    81: 'Safety function faulty',
-    82: 'Wheel motor blocked, rear right',
-    83: 'Wheel motor blocked, rear left',
-    84: 'Wheel drive problem, rear right',
-    85: 'Wheel drive problem, rear left',
-    86: 'Wheel motor overloaded, rear right',
-    87: 'Wheel motor overloaded, rear left',
-    88: 'Angular sensor problem',
-    89: 'Invalid system configuration',
-    90: 'No power in charging station',
-    91: 'Switch cord problem',
-    92: 'Work area not valid',
-    93: 'No accurate position from satellites',
-    94: 'Reference station communication problem',
-    95: 'Folding sensor activated',
-    96: 'Right brush motor overloaded',
-    97: 'Left brush motor overloaded',
-    98: 'Ultrasonic Sensor 1 defect',
-    99: 'Ultrasonic Sensor 2 defect',
-    100:  'Ultrasonic Sensor 3 defect',
-    101:  'Ultrasonic Sensor 4 defect',
-    102:  'Cutting drive motor 1 defect',
-    103:  'Cutting drive motor 2 defect',
-    104:  'Cutting drive motor 3 defect',
-    105:  'Lift Sensor defect',
-    106:  'Collision sensor defect',
-    107:  'Docking sensor defect',
-    108:  'Folding cutting deck sensor defect',
-    109:  'Loop sensor defect',
-    110:  'Collision sensor error',
-    111:  'No confirmed position',
-    112:  'Cutting system major imbalance',
-    113:  'Complex working area',
-    114:  'Too high discharge current',
-    115:  'Too high internal current',
-    116:  'High charging power loss',
-    117:  'High internal power loss',
-    118:  'Charging system problem',
-    119:  'Zone generator problem',
-    120:  'Internal voltage error',
-    121:  'High internal temerature',
-    122:  'CAN error',
-    123:  'Destination not reachable',
-    124:  'Destination blocked',
-    125:  'Battery needs replacement',
-    126:  'Battery near end of life',
-    127:  'Battery problem',
-    701:  'Connectivity problem',
-    702:  'Connectivity settings restored',
-    703:  'Connectivity problem',
-    704:  'Connectivity problem',
-    705:  'Connectivity problem',
-    706:  'Poor signal quality',
-    707:  'SIM card requires PIN',
-    708:  'SIM card locked',
-    709:  'SIM card not found',
-    710:  'SIM card locked',
-    711:  'SIM card locked',
-    712:  'SIM card locked',
-    713:  'Geofence problem',
-    714:  'Geofence problem',
-    715:  'Connectivity problem',
-    716:  'Connectivity problem',
-    717:  'SMS could not be sent',
-    724:  'Communication circuit board SW must be updated'
-}
+@dataclass
+class ApiState:
+    """State information for API communication."""
+    access_token: Optional[Dict[str, Any]] = None
+    access_token_expiration: datetime = field(default_factory=lambda: datetime(2000, 1, 1))
+    timestamp_last_update_mower_list: datetime = field(default_factory=lambda: datetime(2000, 1, 1))
+    error: Optional[str] = None
+    api_limit_reached: bool = False
+    authenticated: bool = False
 
-class Husqvarna():
+class ErrorCodes:
+    """
+    Error codes dictionary for Husqvarna mowers.
+    Maps numeric error codes to human-readable descriptions.
+    """
+    CODES = {
+        0:    'Unexpected error',
+        1:    'Outside working area',
+        2:    'No loop signal',
+        3:    'Wrong loop signal',
+        4:    'Loop sensor problem, front',
+        5:    'Loop sensor problem, rear',
+        6:    'Loop sensor problem, left',
+        7:    'Loop sensor problem, right',
+        8:    'Wrong PIN code',
+        9:    'Trapped',
+        10:   'Upside down',
+        11:   'Low battery',
+        12:   'Empty battery',
+        13:   'No drive',
+        14:   'Mower lifted',
+        15:   'Lifted',
+        16:   'Stuck in charging station',
+        17:   'Charging station blocked',
+        18:   'Collision sensor problem, rear',
+        19:   'Collision sensor problem, front',
+        20:   'Wheel motor blocked, right',
+        21:   'Wheel motor blocked, left',
+        22:   'Wheel drive problem, right',
+        23:   'Wheel drive problem, left',
+        24:   'Cutting system blocked',
+        25:   'Cutting system blocked',
+        26:   'Invalid sub-device combination',
+        27:   'Settings restored',
+        28:   'Memory circuit problem',
+        29:   'Slope too steep',
+        30:   'Charging system problem',
+        31:   'STOP button problem',
+        32:   'Tilt sensor problem',
+        33:   'Mower tilted',
+        34:   'Cutting stopped - slope too steep',
+        35:   'Wheel motor overloaded, right',
+        36:   'Wheel motor overloaded, left',
+        37:   'Charging current too high',
+        38:   'Electronic problem',
+        39:   'Cutting motor problem',
+        40:   'Limited cutting height range',
+        41:   'Unexpected cutting height adj',
+        42:   'Limited cutting height range',
+        43:   'Cutting height problem, drive',
+        44:   'Cutting height problem, curr',
+        45:   'Cutting height problem, dir',
+        46:   'Cutting height blocked',
+        47:   'Cutting height problem',
+        48:   'No response from charger',
+        49:   'Ultrasonic problem',
+        50:   'Guide 1 not found',
+        51:   'Guide 2 not found',
+        52:   'Guide 3 not found',
+        53:   'GPS navigation problem',
+        54:   'Weak GPS signal',
+        55:   'Difficult finding home',
+        56:   'Guide calibration accomplished',
+        57:   'Guide calibration failed',
+        58:   'Temporary battery problem',
+        59:   'Temporary battery problem',
+        60:   'Temporary battery problem',
+        61:   'Temporary battery problem',
+        62:   'Temporary battery problem',
+        63:   'Temporary battery problem',
+        64:   'Temporary battery problem',
+        65:   'Temporary battery problem',
+        66:   'Battery problem',
+        67:   'Battery problem',
+        68:   'Temporary battery problem',
+        69:   'Alarm! Mower switched off',
+        70:   'Alarm! Mower stopped',
+        71:   'Alarm! Mower lifted',
+        72:   'Alarm! Mower tilted',
+        73:   'Alarm! Mower in motion',
+        74:   'Alarm! Outside geofence',
+        75:   'Connection changed',
+        76:   'Connection NOT changed',
+        77:   'Com board not available',
+        78:   'Slipped - Mower has Slipped.Situation not solved with moving pattern',
+        79:   'Invalid battery combination - Invalid combination of different battery types.',
+        80:   'Cutting system imbalance  Warning',
+        81:   'Safety function faulty',
+        82:   'Wheel motor blocked, rear right',
+        83:   'Wheel motor blocked, rear left',
+        84:   'Wheel drive problem, rear right',
+        85:   'Wheel drive problem, rear left',
+        86:   'Wheel motor overloaded, rear right',
+        87:   'Wheel motor overloaded, rear left',
+        88:   'Angular sensor problem',
+        89:   'Invalid system configuration',
+        90:   'No power in charging station',
+        91:   'Switch cord problem',
+        92:   'Work area not valid',
+        93:   'No accurate position from satellites',
+        94:   'Reference station communication problem',
+        95:   'Folding sensor activated',
+        96:   'Right brush motor overloaded',
+        97:   'Left brush motor overloaded',
+        98:   'Ultrasonic Sensor 1 defect',
+        99:   'Ultrasonic Sensor 2 defect',
+        100:  'Ultrasonic Sensor 3 defect',
+        101:  'Ultrasonic Sensor 4 defect',
+        102:  'Cutting drive motor 1 defect',
+        103:  'Cutting drive motor 2 defect',
+        104:  'Cutting drive motor 3 defect',
+        105:  'Lift Sensor defect',
+        106:  'Collision sensor defect',
+        107:  'Docking sensor defect',
+        108:  'Folding cutting deck sensor defect',
+        109:  'Loop sensor defect',
+        110:  'Collision sensor error',
+        111:  'No confirmed position',
+        112:  'Cutting system major imbalance',
+        113:  'Complex working area',
+        114:  'Too high discharge current',
+        115:  'Too high internal current',
+        116:  'High charging power loss',
+        117:  'High internal power loss',
+        118:  'Charging system problem',
+        119:  'Zone generator problem',
+        120:  'Internal voltage error',
+        121:  'High internal temerature',
+        122:  'CAN error',
+        123:  'Destination not reachable',
+        124:  'Destination blocked',
+        125:  'Battery needs replacement',
+        126:  'Battery near end of life',
+        127:  'Battery problem',
+        701:  'Connectivity problem',
+        702:  'Connectivity settings restored',
+        703:  'Connectivity problem',
+        704:  'Connectivity problem',
+        705:  'Connectivity problem',
+        706:  'Poor signal quality',
+        707:  'SIM card requires PIN',
+        708:  'SIM card locked',
+        709:  'SIM card not found',
+        710:  'SIM card locked',
+        711:  'SIM card locked',
+        712:  'SIM card locked',
+        713:  'Geofence problem',
+        714:  'Geofence problem',
+        715:  'Connectivity problem',
+        716:  'Connectivity problem',
+        717:  'SMS could not be sent',
+        724:  'Communication circuit board SW must be updated'
+    }
+    
+    @classmethod
+    def get_description(cls, code: Optional[int]) -> Optional[str]:
+        """Get the error description for a given error code."""
+        if code is None:
+            return None
+        return cls.CODES.get(code, f"Unknown error code: {code}")
 
-    def __init__(self, client_id, client_secret):
-        self.mowers = []
+
+class Husqvarna:
+    """
+    Husqvarna API client for controlling and monitoring Automower devices.
+    This class provides methods to authenticate with the Husqvarna API,
+    retrieve mower information, and send commands to mowers.
+    """
+    
+    def __init__(self, client_id: str, client_secret: str):
+        """
+        Initialize the Husqvarna API client.
+        Args:
+            client_id: The client ID (application ID) from Husqvarna Developer Portal
+            client_secret: The client secret from Husqvarna Developer Portal
+        """
         self.client_id = client_id
         self.client_secret = client_secret
-        self.access_token = None
-        self.access_token_expiration = datetime(2000,1,1)
-        self.timestamp_last_update_mower_list = datetime(2000,1,1)
-        self.error = None
-        self.api_limit_reached = False
-        self.session = self._create_session() # Create session using a method
+        self.mowers: List[Dict[str, Any]] = []
+        self.state = ApiState()
+        self.session = self._create_session()
+        self.state.authenticated = self._get_access_token()
 
-    def __bool__(self):
-        # __bool__ should return True or False.
-        # The current implementation in _get_access_token returns a status boolean, which is fine.
-        log('Return value on creation of Husqvarna object')
-        return self._get_access_token()
+    def __bool__(self) -> bool:
+        """
+        Check if the API client is properly authenticated.
+        Returns:
+            bool: True if authenticated, False otherwise
+        """
+        log(f'Husqvarna object returns {self.state.authenticated}.')
+        return self.state.authenticated
 
-    def __enter__(self):
-        """Enables using the class with a context manager."""
+    def __enter__(self) -> 'Husqvarna':
+        """Context manager entry point."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """Ensures the httpx session is closed when exiting the context."""
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Context manager exit - ensure the session is closed."""
         self.close()
 
-    def _create_session(self):
-        return httpx.Client(verify=False, headers={'x-api-key': self.client_id, 'accept': 'application/vnd.api+json'})
+    def _create_session(self) -> httpx.Client:
+        """
+        Create an HTTP session for API communication.
+        Returns:
+            httpx.Client: Configured HTTP client
+        """
+        return httpx.Client(
+            verify=False,
+            headers={
+                'x-api-key': self.client_id,
+                'accept': 'application/vnd.api+json'
+            }
+        )
 
-    def get_mowers(self):
+    def get_mowers(self) -> bool:
+        """
+        Retrieve the list of mowers associated with the account.
+        Returns:
+            bool: True if successful, False otherwise
+        """
         if self._check_access_token_and_renew():
-            if ( status := self._get_mowers() ):
-                self.timestamp_last_update_mower_list = datetime.now()
-            return status
+            if self._get_mowers():
+                self.state.timestamp_last_update_mower_list = datetime.now()
+                return True
         return False
 
-    def get_mower_messages(self, mower_name):
+    def get_mower_messages(self, mower_name: str) -> Optional[Dict[str, Any]]:
+        """
+        Get messages for a specific mower.
+        Args:
+            mower_name: Name of the mower
+        Returns:
+            Optional[Dict[str, Any]]: Messages if available, None otherwise
+        """
         if not self._check_access_token_and_renew():
-            return False
+            return None
 
-        mower_id = self._find_id_from_name(mower_name)
-        if mower_id:
-            # _http_with_retry handles the GET call via self.session (httpx.Client)
-            if ( mower_messages := self._http_with_retry(GET, f'{URL_GET_MOWERS}/{mower_id}/messages', mower_name=mower_name) ):
-                return mower_messages
+        if ( mower_id := self._find_id_from_name(mower_name) ):
+            return self._http_with_retry(
+                HttpMethod.GET,
+                f'{ApiEndpoints.MOWERS}/{mower_id}/messages',
+                mower_name=mower_name
+            )
         return None
 
-    def get_mowers_info(self):
+    def get_mowers_info(self) -> bool:
+        """
+        Get detailed information for all mowers.
+        Returns:
+            bool: True if successful, False otherwise
+        """
         if self._check_access_token_and_renew():
-            # _get_mower_detailed_info calls _http_with_retry which uses self.session (httpx.Client)
             return self._get_mower_detailed_info()
         return False
 
-    def action_ParkUntilNextSchedule(self, mower_name):
-        return self._send_action_to_mower(mower_name, ACTION_PARKNEXTSCHEDULE)
+    def get_mower_from_name(self, mower_name: str) -> Optional[Dict[str, Any]]:
+        """
+        Get mower data by name.
+        Args:
+            mower_name: Name of the mower
+        Returns:
+            Optional[Dict[str, Any]]: Mower data if found, None otherwise
+        """
+        for mower in self.mowers:
+            if mower.get('name') == mower_name:
+                return mower
+        return None
 
-    def action_ParkUntilFurtherNotice(self, mower_name):
-        return self._send_action_to_mower(mower_name, ACTION_PARKFURTHERNOTICE)
+    def action_ParkUntilNextSchedule(self, mower_name: str) -> bool:
+        """
+        Command the mower to park until the next scheduled mowing session.
+        Args:
+            mower_name: Name of the mower
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        return self._send_action_to_mower(mower_name, MowerAction.PARK_NEXT_SCHEDULE)
 
-    def action_Pause(self, mower_name):
-        return self._send_action_to_mower(mower_name, ACTION_PAUSE)
+    def action_ParkUntilFurtherNotice(self, mower_name: str) -> bool:
+        """
+        Command the mower to park until manually started again.
+        Args:
+            mower_name: Name of the mower
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        return self._send_action_to_mower(mower_name, MowerAction.PARK_FURTHER_NOTICE)
 
-    def action_ResumeSchedule(self, mower_name):
-        return self._send_action_to_mower(mower_name, ACTION_RESUMESCHEDULE)
+    def action_Pause(self, mower_name: str) -> bool:
+        """
+        Pause the mower's current operation.
+        Args:
+            mower_name: Name of the mower
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        return self._send_action_to_mower(mower_name, MowerAction.PAUSE)
 
-    def action_Start(self, mower_name, duration=60):
-        return self._send_action_to_mower(mower_name, ACTION_START, duration=duration)
+    def action_ResumeSchedule(self, mower_name: str) -> bool:
+        """
+        Resume the mower's normal schedule.
+        Args:
+            mower_name: Name of the mower
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        return self._send_action_to_mower(mower_name, MowerAction.RESUME_SCHEDULE)
 
-    def get_mower_from_name(self, mower_name):
-        return next( (mower for mower in self.mowers if mower['name'] == mower_name), None)
+    def action_Start(self, mower_name: str, duration: int = 60) -> bool:
+        """
+        Start mowing for a specified duration.
+        Args:
+            mower_name: Name of the mower
+            duration: Mowing duration in minutes (default: 60)
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        return self._send_action_to_mower(mower_name, MowerAction.START, duration=duration)
 
-    def set_headlight(self, mower_name, light):
+    def set_headlight(self, mower_name: str, light: bool) -> bool:
+        """
+        Set the mower's headlight state.
+        Args:
+            mower_name: Name of the mower
+            light: True to turn on, False to turn off
+        Returns:
+            bool: True if successful, False otherwise
+        """
         if not self._check_access_token_and_renew():
             return False
 
         if ( mower_id := self._find_id_from_name(mower_name) ):
-            json_payload = { 'data': {'type': 'settings', 'attributes': {'headlight': {'mode': 'ALWAYS_ON'} } } } if light else { 'data': {'type': 'settings', 'attributes': {'headlight': {'mode': 'ALWAYS_OFF'} } } } 
-            self.session.headers.update( { 'Content-Type': 'application/vnd.api+json' } )
-            if ( action := self._http_with_retry(POST, f'{URL_GET_MOWERS}/{mower_id}/settings', json_post_data=json_payload, mower_name=mower_name) ):
-                return True
+            headlight_mode = 'ALWAYS_ON' if light else 'ALWAYS_OFF'
+            json_payload = {
+                'data': {
+                    'type': 'settings',
+                    'attributes': {
+                        'headlight': {
+                            'mode': headlight_mode
+                        }
+                    }
+                }
+            }
+            
+            self.session.headers.update({'Content-Type': 'application/vnd.api+json'})
+            response = self._http_with_retry(
+                HttpMethod.POST,
+                f'{ApiEndpoints.MOWERS}/{mower_id}/settings',
+                json_post_data=json_payload,
+                mower_name=mower_name
+            )
+            return bool(response)
         return False
 
-    def set_cutting_height(self, mower_name, height):
+    def set_cutting_height(self, mower_name: str, height: float) -> bool:
+        """
+        Set the mower's cutting height.
+        Args:
+            mower_name: Name of the mower
+            height: Cutting height in centimeters
+        Returns:
+            bool: True if successful, False otherwise
+        """
         if not self._check_access_token_and_renew():
             return False
 
         if ( mower_id := self._find_id_from_name(mower_name) ):
-            json_payload = { 'data': {'type': 'settings', 'attributes': {'cuttingHeight': height } } }
-            self.session.headers.update( { 'Content-Type': 'application/vnd.api+json' } )
-            if ( action := self._http_with_retry(POST, f'{URL_GET_MOWERS}/{mower_id}/settings', json_post_data=json_payload, mower_name=mower_name) ):
-                return True
+            json_payload = {
+                'data': {
+                    'type': 'settings',
+                    'attributes': {
+                        'cuttingHeight': height
+                    }
+                }
+            }
+            
+            self.session.headers.update({'Content-Type': 'application/vnd.api+json'})
+            response = self._http_with_retry(
+                HttpMethod.POST,
+                f'{ApiEndpoints.MOWERS}/{mower_id}/settings',
+                json_post_data=json_payload,
+                mower_name=mower_name
+            )
+            return bool(response)
         return False
 
+    def get_timestamp_last_update_mower_list(self) -> datetime:
+        """
+        Get the timestamp of the last update of the mower list.
+        Returns:
+            datetime: Timestamp of last update
+        """
+        return self.state.timestamp_last_update_mower_list
 
-    def are_all_mowers_off(self):
-        return all(mower.get('state', None) == STATE_OFF for mower in self.mowers)
+    def is_mower_off(self, name_or_mower: Union[str, Dict[str, Any]]) -> Optional[bool]:
+        """
+        Check if a mower is in the OFF state.
+        Args:
+            name_or_mower: Either the mower name or a mower dict
+        Returns:
+            Optional[bool]: True if off, False if on, None if mower not found
+        """
+        if isinstance(name_or_mower, dict):
+            mower = name_or_mower
+        else:
+            mower = self.get_mower_from_name(name_or_mower)
+        if mower:
+            return mower.get('state') == MowerState.OFF.value
+        return None
 
-    def get_timestamp_last_update_mower_list(self):
-        return self.timestamp_last_update_mower_list
+    def are_all_mowers_off(self) -> bool:
+        """
+        Check if all mowers are in the OFF state.
+        Returns:
+            bool: True if all mowers are off, False otherwise
+        """
+        return all(
+            mower.get('state') == MowerState.OFF.value
+            for mower in self.mowers
+        )
 
-    def is_mower_off(self, name_or_mower):
-        mower = name_or_mower if isinstance(name_or_mower, dict) else self.get_mower_from_name(name_or_mower)
-        return mower.get('state') == STATE_OFF if mower else None
+    def are_api_limits_reached(self) -> bool:
+        """
+        Check if API rate limits have been reached.
+        Returns:
+            bool: True if limits reached, False otherwise
+        """
+        return self.state.api_limit_reached
 
-    def are_api_limits_reached(self):
-        return self.api_limit_reached
+    def close(self) -> None:
+        """Close the HTTP session."""
+        if self.session:
+            self.session.close()
 
-    def close(self):
-        self.session.close()
+    def get_http_error(self) -> Optional[str]:
+        """
+        Get the last HTTP error message.
+        Returns:
+            Optional[str]: Error message or None if no error
+        """
+        return self.state.error
 
-    def get_http_error(self):
-        return self.error
-
-    def _get_access_token(self):
+    def _get_access_token(self) -> bool:
+        """
+        Authenticate with the Husqvarna API and get an access token.
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        # Clear existing headers
         self.session.headers.clear()
         self.session.headers.update({'Content-Type': 'application/x-www-form-urlencoded'})
-        data = { 'grant_type': 'client_credentials',
-                 'client_id' : self.client_id,
-                 'client_secret': self.client_secret,
-                 'token_endpoint': URL_TOKEN_REQUEST
-               }
-        self.access_token = self._http_with_retry(POST, URL_TOKEN_REQUEST, post_data=data)
-
-        # Return True if authenticated
-        if self.access_token:
-            self.error = None
-            self.access_token_expiration = datetime.now() + timedelta(seconds=self.access_token.get('expires_in', 0)) - timedelta(seconds=600)
-            # Headers worden op de self.session (httpx.Client) beheerd, update() werkt hetzelfde
-            self.session.headers.update( {
+        
+        # Prepare authentication data
+        auth_data = {
+            'grant_type': 'client_credentials',
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'token_endpoint': ApiEndpoints.TOKEN_REQUEST
+        }
+        
+        # Make the request
+        response = self._http_with_retry(
+            HttpMethod.POST,
+            ApiEndpoints.TOKEN_REQUEST,
+            post_data=auth_data
+        )
+        
+        # Process the response
+        if response:
+            self.state.access_token = response
+            self.state.error = None
+            
+            # Calculate token expiration time with a safety margin
+            self.state.access_token_expiration = (
+                datetime.now() + 
+                timedelta(seconds=response.get('expires_in', 0)) - 
+                timedelta(seconds=ApiConfig.TOKEN_REFRESH_MARGIN)
+            )
+            
+            # Update session headers with token
+            self.session.headers.update({
                 'x-api-key': self.client_id,
-                'Authorization': f"{self.access_token.get('token_type', '')} {self.access_token.get('access_token', '')}",
-                'Authorization-Provider': self.access_token.get('provider', ''),
+                'Authorization': f"{response.get('token_type', '')} {response.get('access_token', '')}",
+                'Authorization-Provider': response.get('provider', ''),
                 'accept': 'application/vnd.api+json'
-            } )
-            log(f"New access token generated!!! Expiration: {datetime.now() + timedelta(seconds=self.access_token.get('expires_in', 0))} - Type: {self.access_token.get('token_type', '')} - Token: ...{self.access_token.get('access_token', 'N/A')[-20:]}.")
+            })
+            
+            log(f"New access token generated! Expiration: {datetime.now() + timedelta(seconds=response.get('expires_in', 0))} - "
+                f"Type: {response.get('token_type', '')} - Token: ...{response.get('access_token', 'N/A')[-20:]}.")
+                
             return True
         else:
-            self.error = f'Bad or unauthorized authentication request (url: {URL_TOKEN_REQUEST}).'
+            self.state.error = f'Bad or unauthorized authentication request (url: {ApiEndpoints.TOKEN_REQUEST}).'
             return False
 
-    def _check_access_token_and_renew(self):
-        if datetime.now() > self.access_token_expiration:
-            log('Create new access token!!!')
-            return self._get_access_token()
-        log(f"Use existing access token!!! Expiration: {datetime.now() + timedelta(seconds=self.access_token.get('expires_in', 0))} - Type: {self.access_token.get('token_type', '')} - Token: ...{self.access_token.get('access_token', 'N/A')[-20:]}.")
-        return True
+    def _check_access_token_and_renew(self) -> bool:
+        """
+        Check if the current access token is valid and renew if needed.
+        Returns:
+            bool: True if a valid token is available, False otherwise
+        """
+        if datetime.now() > self.state.access_token_expiration:
+            log('Create new access token!')
+            self.state.authenticated = self._get_access_token() 
+            return self.state.authenticated
+            
+        log(f"Use existing access token! Expiration: "
+            f"{self.state.access_token_expiration} - "
+            f"Type: {self.state.access_token.get('token_type', '') if self.state.access_token else 'N/A'} - "
+            f"Token: ...{self.state.access_token.get('access_token', 'N/A')[-20:] if self.state.access_token else 'N/A'}.")
 
-    def _get_mowers(self):
-        if ( mowers := self._http_with_retry(GET, URL_GET_MOWERS) ):
-            self.mowers = [{'id': mower.get('id'), 'name': mower.get('attributes', {}).get('system', {}).get('name')} for mower in mowers.get('data', [])]
-            return True
+        self.state.authenticated = True    
+        return self.state.authenticated
+
+    def _get_mowers(self) -> bool:
+        """
+        Retrieve the list of mowers from the API.
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        response = self._http_with_retry(HttpMethod.GET, ApiEndpoints.MOWERS)
+        if response:
+            # Extract mower IDs and names
+            try:
+                self.mowers = [
+                    {
+                        'id': mower.get('id'),
+                        'name': mower.get('attributes', {}).get('system', {}).get('name')
+                    }
+                    for mower in response.get('data', [])
+                ]
+                return True
+            except (KeyError, TypeError) as e:
+                log(f"Error parsing mower list: {e}")
+                return False
         return False
 
-    def _get_mower_detailed_info(self):
+    def _get_mower_detailed_info(self) -> bool:
+        """
+        Retrieve detailed information for all mowers.
+        Returns:
+            bool: True if successful for all mowers, False otherwise
+        """
         status = True
+        
         for index, mower in enumerate(self.mowers):
-            mower_info = self._http_with_retry(GET, f"{URL_GET_MOWERS}/{mower.get('id')}", mower_name=self.mowers[index].get('name'))
+            mower_id = mower.get('id')
+            mower_name = mower.get('name')
+            
+            if not mower_id or not mower_name:
+                log(f"Skipping mower at index {index} due to missing ID or name")
+                status = False
+                continue
+                
+            # Request detailed mower information
+            mower_info = self._http_with_retry(
+                HttpMethod.GET,
+                f"{ApiEndpoints.MOWERS}/{mower_id}",
+                mower_name=mower_name
+            )
+            
             if mower_info and 'data' in mower_info:
-                attributes = mower_info['data'].get('attributes', {})
-                self.mowers[index]['battery_pct'] = attributes.get('battery', {}).get('batteryPercent')
-                self.mowers[index]['activity'] = attributes.get('mower', {}).get('activity')
-                self.mowers[index]['state'] = attributes.get('mower', {}).get('state')
-                positions = attributes.get('positions', [])
-                self.mowers[index]['location'] = positions[0] if positions else None
-                self.mowers[index]['cutting_height'] = attributes.get('settings', {}).get('cuttingHeight')
                 try:
-                    error_code = attributes.get('mower', {}).get('errorCode')
-                    self.mowers[index]['error_state'] = ErrorCodes.get(error_code) if self.mowers[index].get('state') == 'ERROR' and error_code is not None else None
-                except:
-                    self.mowers[index]['error_state'] = None
+                    # Extract and store relevant information
+                    attributes = mower_info['data'].get('attributes', {})
+                    
+                    # Battery information
+                    self.mowers[index]['battery_pct'] = attributes.get('battery', {}).get('batteryPercent')
+                    
+                    # Status information
+                    self.mowers[index]['activity'] = attributes.get('mower', {}).get('activity')
+                    self.mowers[index]['state'] = attributes.get('mower', {}).get('state')
+                    
+                    # Position information
+                    positions = attributes.get('positions', [])
+                    self.mowers[index]['location'] = positions[0] if positions else None
+                    
+                    # Settings
+                    self.mowers[index]['cutting_height'] = attributes.get('settings', {}).get('cuttingHeight', 0)
+
+                    # Schedule information (used by plugin for 'Next Schedule' device)
+                    # Schedule information (used by plugin for 'Next Schedule' device)
+                    planner = attributes.get('planner', {})
+                    self.mowers[index]['schedules'] = None  # tasks-based schedules not used
+                    self.mowers[index]['next_start_timestamp'] = planner.get('nextStartTimestamp')
+                    self.mowers[index]['restricted_reason'] = planner.get('restrictedReason')
+                    
+                    # Error information
+                    try:
+                        error_code = attributes.get('mower', {}).get('errorCode')
+                        if self.mowers[index].get('state') == MowerState.ERROR.value and error_code is not None:
+                            self.mowers[index]['error_state'] = ErrorCodes.get_description(error_code)
+                        else:
+                            self.mowers[index]['error_state'] = None
+                    except Exception as e:
+                        log(f"Error getting error state: {e}")
+                        self.mowers[index]['error_state'] = None
+                        
+                except Exception as e:
+                    log(f"Error parsing mower info for {mower_name}: {e}")
+                    status = False
+                    break
             else:
                 status = False
-                log(f"Failed to get detailed info for mower index {index}: {self.get_http_error()}")
+                log(f"Failed to get detailed info for mower {mower_name}: {self.get_http_error()}")
                 break
+                
         return status
 
-    def _send_action_to_mower(self, mower_name, action, duration=60):
-        if action not in [ACTION_PARKNEXTSCHEDULE, ACTION_PARKFURTHERNOTICE, ACTION_PAUSE, ACTION_RESUMESCHEDULE, ACTION_START]:
+    def _send_action_to_mower(
+        self, 
+        mower_name: str, 
+        action: MowerAction, 
+        duration: int = 60
+    ) -> bool:
+        """
+        Send a command action to a mower.
+        Args:
+            mower_name: Name of the mower
+            action: The action to perform
+            duration: Duration in minutes for timed actions (default: 60)
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        # Validate the action
+        if action not in [
+            MowerAction.PARK_NEXT_SCHEDULE,
+            MowerAction.PARK_FURTHER_NOTICE,
+            MowerAction.PAUSE,
+            MowerAction.RESUME_SCHEDULE,
+            MowerAction.START
+        ]:
             log(f"Unknown action requested: {action}")
             return False
-
+            
+        # Check token and get mower ID
         if not self._check_access_token_and_renew():
             return False
+            
+        mower_id = self._find_id_from_name(mower_name)
+        if not mower_id:
+            return False
+            
+        # Prepare payload
+        if action == MowerAction.START:
+            json_payload = {
+                'data': {
+                    'type': action,
+                    'attributes': {
+                        'duration': duration
+                    }
+                }
+            }
+        else:
+            json_payload = {
+                'data': {
+                    'type': action
+                }
+            }
+            
+        # Send the command
+        self.session.headers.update({'Content-Type': 'application/vnd.api+json'})
+        response = self._http_with_retry(
+            HttpMethod.POST,
+            f'{ApiEndpoints.MOWERS}/{mower_id}/actions',
+            json_post_data=json_payload,
+            mower_name=mower_name
+        )
+        
+        return bool(response)
 
-        if ( mower_id := self._find_id_from_name(mower_name) ):
-            if action == ACTION_START:
-                json_payload = { 'data': {'type': action, 'attributes': {'duration': duration} } }
-            else:
-                json_payload = { 'data': {'type': action} }
-            self.session.headers.update( { 'Content-Type': 'application/vnd.api+json' } )
-            if self._http_with_retry(POST, f'{URL_GET_MOWERS}/{mower_id}/actions', json_post_data=json_payload, mower_name=mower_name):
-                 return True
-        return False
-
-    def _find_id_from_name(self, name):
+    def _find_id_from_name(self, name: str) -> Optional[str]:
+        """
+        Find a mower's ID from its name.
+        Args:
+            name: Mower name
+        Returns:
+            Optional[str]: Mower ID if found, None otherwise
+        """
         mower = self.get_mower_from_name(name)
         return mower.get('id') if mower else None
 
-    def _analyze_http_error(self, response, url, mower_name=None):
-        #API limits reached
-        self.api_limit_reached = True if response.status_code == 429 else False
-
+    def _analyze_http_error(
+        self, 
+        response: httpx.Response, 
+        url: str, 
+        mower_name: Optional[str] = None
+    ) -> str:
+        """
+        Analyze an HTTP error response and create an informative error message.
+        Args:
+            response: The HTTP response
+            url: The request URL
+            mower_name: Optional mower name for context
+        Returns:
+            str: Formatted error message
+        """
+        # Check for API rate limiting
+        self.state.api_limit_reached = (response.status_code == 429)
+        
         try:
+            # Try to parse error details from JSON response
             error_info = response.json()
+            
             if 'errors' in error_info:
                 error_detail = error_info['errors'][0] if error_info['errors'] else {}
-                return f"({mower_name} - {response.status_code}) {error_detail.get('title', 'Unknown Error')}: {error_detail.get('detail', 'No detail')} (url: {url})"
+                return f"({mower_name or 'Unknown'} - {response.status_code}) {error_detail.get('title', 'Unknown Error')}: {error_detail.get('detail', 'No detail')} (url: {url})"
+                
             elif 'message' in error_info:
-                 return f"({mower_name} - {response.status_code}) {error_info.get('message', 'No message')} (url: {url})"
+                return f"({mower_name or 'Unknown'} - {response.status_code}) {error_info.get('message', 'No message')} (url: {url})"
+                
             else:
-                return f"({mower_name} - {response.status_code}) Uncaptured error returned by Husqvarna API (url: {url})"
-        except httpx.JSONDecodeError:
-            return f"({mower_name} - {response.status_code}) Uncaptured error returned by Husqvarna API (url: {url}, response: {response.text}) - JSON decode error"
+                return f"({mower_name or 'Unknown'} - {response.status_code}) Uncaptured error returned by Husqvarna API (url: {url})"
+                
+        except (httpx.JSONDecodeError, json.JSONDecodeError):
+            # Handle non-JSON responses
+            return f"({mower_name or 'Unknown'} - {response.status_code}) Uncaptured error returned by Husqvarna API (url: {url}, response: {response.text}) - JSON decode error"
+            
         except Exception as e:
-             return f"({mower_name} - {response.status_code}) Error analyzing API response (url: {url}, response: {response.text}): {e}"
+            # Handle unexpected errors during analysis
+            return f"({mower_name or 'Unknown'} - {response.status_code}) Error analyzing API response (url: {url}, response: {response.text}): {e}"
 
-    def _http_with_retry(self, mode, url, json_post_data=None, post_data=None, mower_name=None):
+    def _http_with_retry(
+        self, 
+        method: HttpMethod, 
+        url: str, 
+        json_post_data: Optional[Dict[str, Any]] = None, 
+        post_data: Optional[Dict[str, Any]] = None, 
+        mower_name: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Send an HTTP request with automatic retry for certain error conditions.
+        Args:
+            method: HTTP method (GET or POST)
+            url: Request URL
+            json_post_data: Optional JSON data for POST requests
+            post_data: Optional form data for POST requests
+            mower_name: Optional mower name for context
+        Returns:
+            Optional[Dict[str, Any]]: JSON response if successful, None otherwise
+        """
         retry_counter = 0
         execution_status = False
-        self.error = ''
+        self.state.error = ''
+        response = None
 
-        while retry_counter < 3: 
+        while retry_counter < 3:
             try:
-                if mode == GET:
-                    r = self.session.get(url, timeout=API_TIMEOUT)
-                else: # mode == POST
-                    r = self.session.post(url, json=json_post_data, data=post_data, timeout=API_TIMEOUT)
+                # Make the request
+                if method == HttpMethod.GET:
+                    response = self.session.get(url, timeout=ApiConfig.TIMEOUT)
+                else:  # method == HttpMethod.POST
+                    response = self.session.post(
+                        url, 
+                        json=json_post_data, 
+                        data=post_data, 
+                        timeout=ApiConfig.TIMEOUT
+                    )
 
-                # All good (2xx status codes)
-                if 200 <= r.status_code < 300:
-                    self.error = None
-                    self.api_limit_reached = False
+                # Handle different response categories
+                if 200 <= response.status_code < 300:
+                    # Success - 2xx status codes
+                    self.state.error = None
+                    self.state.api_limit_reached = False
                     execution_status = True
                     break
-
-                #Authentication error received: following the exchange with the helpdesk openapi.servicedesk@husqvarnagroup.com, there
-                #are regularly timeouts on the commands that translates also in an authentication error. Hence adding also retries...
-                elif r.status_code == 403:
-                     log(f"Retry {retry_counter} - Authentication error (403) for url {url}. Retrying...")
-                     retry_counter += 1
-                     if retry_counter >= 3:
-                         self.error = self._analyze_http_error(r, url, mower_name)
-                         break
-
-                # Client error (4xx), not 403
-                elif 400 <= r.status_code < 500:
-                    if r.status_code == 429: # Specific check for API limits
-                        log(f"Retry {retry_counter} - API limit reached (429) for url {url}.")
-                    else:
-                        log(f"Retry {retry_counter} - Client error ({r.status_code}) for url {url}. No retry.")
-                    self.error = self._analyze_http_error(r, url, mower_name)
-                    break
-
-                # Server error (5xx)
-                elif 500 <= r.status_code < 600:
-                    log(f"Retry {retry_counter} - Server error ({r.status_code}) for url {url}. Retrying...")
+                    
+                elif response.status_code == 403:
+                    # Authentication error (403) - retry a few times
+                    # Following the exchange with the helpdesk openapi.servicedesk@husqvarnagroup.com, there
+                    # are regularly timeouts on the commands that translates also in an authentication error. Hence adding also retries...
+                    log(f"Retry {retry_counter} - Authentication error (403) for url {url}. Retrying...")
                     retry_counter += 1
                     if retry_counter >= 3:
-                        self.error = self._analyze_http_error(r, url, mower_name)
+                        self.state.error = self._analyze_http_error(response, url, mower_name)
                         break
-
-                # Other errors
+                        
+                elif 400 <= response.status_code < 500:
+                    # Other client errors (4xx) - don't retry
+                    if response.status_code == 429:
+                        log(f"Retry {retry_counter} - API limit reached (429) for url {url}.")
+                    else:
+                        log(f"Retry {retry_counter} - Client error ({response.status_code}) for url {url}. No retry.")
+                    self.state.error = self._analyze_http_error(response, url, mower_name)
+                    break
+                    
+                elif 500 <= response.status_code < 600:
+                    # Server errors (5xx) - retry
+                    log(f"Retry {retry_counter} - Server error ({response.status_code}) for url {url}. Retrying...")
+                    retry_counter += 1
+                    if retry_counter >= 3:
+                        self.state.error = self._analyze_http_error(response, url, mower_name)
+                        break
+                        
                 else:
-                    log(f"Retry {retry_counter} - Unhandled HTTP status code ({r.status_code}) for url {url}. No retry.")
-                    self.error = f'HTTP error ({r.status_code}) not specifically handled.'
+                    # Unexpected status codes
+                    log(f"Retry {retry_counter} - Unhandled HTTP status code ({response.status_code}) for url {url}. No retry.")
+                    self.state.error = f'HTTP error ({response.status_code}) not specifically handled.'
                     break
 
             except (httpx.TimeoutException, httpx.ConnectError, httpx.RequestError) as e:
-                self.error = f'Retry {retry_counter} - Connection error to url {url} with error "{e}".\n'
-                log(self.error.strip())
+                # Connection and timeout errors
+                self.state.error = f'Retry {retry_counter} - Connection error to url {url} with error "{e}".\n'
+                log(self.state.error.strip())
                 retry_counter += 1
                 if retry_counter >= 3:
                     break
 
+            # Wait before retrying
             if retry_counter < 3 and not execution_status:
-                time.sleep(API_CALL_DELAY*(retry_counter+1))
+                time.sleep(ApiConfig.RETRY_DELAY * (retry_counter + 1))
 
-        return r.json() if execution_status and 'r' in locals() and r is not None else None
+        # Return parsed JSON response if successful
+        if execution_status and response is not None:
+            try:
+                return response.json()
+            except (json.JSONDecodeError, httpx.JSONDecodeError) as e:
+                log(f"Error parsing JSON response: {e}")
+                self.state.error = f"Error parsing JSON response: {e}"
+                return None
+        return None
 
 
 if __name__ == "__main__":
-    husq = Husqvarna('xxxxxxxxxxxx', 'yyyyyyyyyyyyyyy')
+    """
+    Example usage of the Husqvarna API client.
+    This will authenticate, get mower information, and continuously
+    monitor mower status if run directly.
+    """
+    # Example credentials - replace with your own
+    CLIENT_ID = 'xxx'
+    CLIENT_SECRET = 'yyy'
+    
+    husq = Husqvarna(CLIENT_ID, CLIENT_SECRET)
+    
     if husq:
         if husq.get_mowers() and husq.get_mowers_info():
             print(husq.mowers)
-            #print(f"Execute ParkUntilFurtherNotice: {husq.action_ParkUntilFurtherNotice(husq.mowers[0]['name'])} - {husq.get_http_error()}"
+            #print(f"Execute ParkUntilFurtherNotice: {husq.action_ParkUntilFurtherNotice(husq.mowers[0]['name'])} - {husq.get_http_error()}")
         else:
             print(f'Error getting mower information: {husq.get_http_error()}')
+            
+        # Continuous monitoring example
         while True:
             print(f'are_all_mowers_off: {husq.are_all_mowers_off()}')
-            if husq.get_mowers_info(): 
+            
+            if husq.get_mowers_info():
                 print(f'({datetime.now()}) {husq.mowers}')
                 print(f"Get messages: {husq.get_mower_messages(husq.mowers[0]['name'])} - {husq.get_http_error()}")
             else:
                 print(f'({datetime.now()}) Error getting mower information: {husq.get_http_error()}')
-            import time
+                
             time.sleep(30)
     else:
-        print(husq.error)
+        print(husq.get_http_error())

--- a/plugin.py
+++ b/plugin.py
@@ -99,6 +99,18 @@ import Husqvarna
 </plugin>
 """
 
+# Human-readable labels for mower activities (shared across methods)
+ACTIVITY_LOG_MAP = {
+    'UNKNOWN':           'Unknown',
+    'NOT_APPLICABLE':    'Not applicable',
+    'MOWING':            'Mowing',
+    'GOING_HOME':        'Going home',
+    'CHARGING':          'Charging',
+    'LEAVING':           'Leaving charging station',
+    'PARKED_IN_CS':      'Parked in charging station',
+    'STOPPED_IN_GARDEN': 'Stopped in garden',
+}
+
 class UnitId(IntEnum):
     """Unit identifiers for Husqvarna mower devices in Domoticz."""
     STATE = 1
@@ -183,6 +195,7 @@ class HusqvarnaPlugin:
             name='QueueThread', 
             target=self._handle_tasks
         )
+        self.previous_activity = {}  # type: Dict[str, str]
 
     def on_start(self) -> None:
         """Handle the plugin startup process."""
@@ -222,11 +235,10 @@ class HusqvarnaPlugin:
             # Default values if config file not found or invalid
             default_height_min_max = {"min": 2, "max": 6, "steps": 9}
             position_parts = Settings['Location'].split(';')
-            # Check if position_parts has at least two elements and they can be converted to float
             if len(position_parts) >= 2 and all(isinstance(p, str) and p.strip().replace('.', '', 1).isdigit() for p in position_parts[:2]):
                 default_zones = [{"name": Settings['Title'], "latitude": float(position_parts[0]), "longitude": float(position_parts[1])}]
             else:
-                default_zones = [] # No valid location in settings
+                default_zones = []
 
             self.config.height_min_max = default_height_min_max
             self.config.zones = default_zones
@@ -264,14 +276,11 @@ class HusqvarnaPlugin:
         Domoticz.Debug('onStop called')
         self.stop_requested = True
         
-        # Signal queue thread to exit
         self.tasks_queue.put(None)
         
-        # Wait for thread to exit
         if self.tasks_thread and self.tasks_thread.is_alive():
             self.tasks_thread.join(timeout=10)
 
-        # Wait until queue thread has exited
         Domoticz.Debug(f'Threads still active: {threading.active_count()} (should be 1)')
         end_time = time.time() + 70
         while (threading.active_count() > 1) and (time.time() < end_time):
@@ -295,7 +304,7 @@ class HusqvarnaPlugin:
         Handle commands sent to the plugin from Domoticz.
         Args:
             device_id: The device identifier
-            unit: The unit within the device 
+            unit: The unit within the device
             command: The command to execute
             level: The level parameter for the command
             color: The color parameter for the command
@@ -320,19 +329,13 @@ class HusqvarnaPlugin:
             Domoticz.Error(f"Husqvarna mower {mower['name']} is switched off and cannot execute commands.")
             return
             
-        # Initialize execution status for this mower if not exists
         if device_id not in self.execution_status:
             self.execution_status[device_id] = ExecutionState()
             
-        # Handle Run switch (On/Off)
         if unit == UnitId.RUN:
             self._handle_run_command(device_id, mower, command)
-                
-        # Handle cutting height adjustment
         elif unit == UnitId.CUTTING and command == 'Set Level':
             self._handle_cutting_height_command(device_id, mower, level)
-                
-        # Handle action selector
         elif unit == UnitId.ACTIONS and command == 'Set Level' and level:
             self._handle_action_command(device_id, mower, level)
 
@@ -352,7 +355,7 @@ class HusqvarnaPlugin:
                 exec_state.action = HusqvarnaAction.START.value
                 update_device(False, Devices, device_id, UnitId.RUN, 1, 1)
                 self.tasks_queue.put({'Action': HusqvarnaAction.START.value, 'Mower_name': mower['name']})
-        else: # Command is 'Off'
+        else:
             exec_state.action = HusqvarnaAction.PARK_UNTIL_FURTHER_NOTICE.value
             exec_state.status = ExecutionStatus.INITIATED
             exec_state.command_data.clear()
@@ -368,8 +371,6 @@ class HusqvarnaPlugin:
         exec_state.command_data.clear()
         exec_state.retries = 0
         
-        # Calculate actual cutting height (level/10 + 1)
-        # Assuming the level in Domoticz 0, 10, 20, ...
         cutting_height = (level // 10) + 1
         self.tasks_queue.put({
             'Action': HusqvarnaAction.SET_CUTTING_HEIGHT.value, 
@@ -385,7 +386,6 @@ class HusqvarnaPlugin:
         exec_state.command_data.clear()
         exec_state.retries = 0
         
-        # Map levels to actions
         action_map = {
             10: {'action': HusqvarnaAction.START_6H.value, 'check_charging': True},
             20: {'action': HusqvarnaAction.PAUSE.value},
@@ -398,7 +398,6 @@ class HusqvarnaPlugin:
             action_info = action_map[level]
             action = action_info['action']
             
-            # Check if we need to prevent starting when charging
             if action_info.get('check_charging', False) and mower.get('activity') == 'CHARGING':
                 exec_state.status = ExecutionStatus.DONE
                 Domoticz.Status(f"Mower {mower['name']} cannot be started as it is still charging.")
@@ -425,25 +424,20 @@ class HusqvarnaPlugin:
 
         self.run_again -= 1
         if self.run_again <= 0:
-            # If API not initialized, try to login
             if self.husqvarna_api is None:
                 self.tasks_queue.put({'Action': HusqvarnaAction.LOGIN.value})
             
-            # Refresh mower list daily
             now = datetime.datetime.now()
             if (self.husqvarna_api and 
                 self.husqvarna_api.get_timestamp_last_update_mower_list() and
                 self.husqvarna_api.get_timestamp_last_update_mower_list() + datetime.timedelta(days=1) < now):
                 self.tasks_queue.put({'Action': HusqvarnaAction.GET_MOWERS.value})
                 
-            # Update mower status
             self.tasks_queue.put({'Action': HusqvarnaAction.GET_STATUS.value})
             
-            # Retry failed commands
             if self.husqvarna_api and self.husqvarna_api.mowers:
                 self._retry_failed_commands()
                 
-            # Dynamic adaptation of update frequency
             self._adjust_update_frequency()
 
     def _retry_failed_commands(self) -> None:
@@ -483,21 +477,18 @@ class HusqvarnaPlugin:
         if self.system_retries > 5:
             configured_interval_minutes = float(Parameters.get('Mode5', '1').replace(',','.'))
             self.run_again = min(12*60*DomoticzConstants.MINUTE, self.system_retries*DomoticzConstants.MINUTE*configured_interval_minutes)
-
             if self.speed_status != UpdateSpeed.SYSTEM_ERROR:
                 Domoticz.Status(f'Reduce status update speed to {self.run_again/DomoticzConstants.MINUTE} minutes because of too many errors from Husqvarna Cloud.')
                 self.speed_status = UpdateSpeed.SYSTEM_ERROR
 
         elif self.husqvarna_api and self.husqvarna_api.are_api_limits_reached():
             self.run_again = max(60 * DomoticzConstants.MINUTE, self.run_again)
-            
             if self.speed_status != UpdateSpeed.LIMITS_EXCEEDED:
                 Domoticz.Status(f'Reduce status update speed to {self.run_again/DomoticzConstants.MINUTE} minutes as Husqvarna API limits are reached!')
                 self.speed_status = UpdateSpeed.LIMITS_EXCEEDED
                 
         elif self.husqvarna_api and self.husqvarna_api.are_all_mowers_off():
             self.run_again = 60 * DomoticzConstants.MINUTE
-            
             if self.speed_status != UpdateSpeed.ALL_OFF:
                 Domoticz.Status(f'Reduce status update speed to {self.run_again/DomoticzConstants.MINUTE} minutes as all Husqvarna mowers are off.')
                 self.speed_status = UpdateSpeed.ALL_OFF
@@ -509,7 +500,6 @@ class HusqvarnaPlugin:
         
         elif hours >= 22 or hours <= 5:
             self.run_again = DomoticzConstants.MINUTE * 180
-            
             if self.speed_status != UpdateSpeed.NIGHT:
                 Domoticz.Status(f'Reduce status update speed to {self.run_again/DomoticzConstants.MINUTE} minutes during nighttime hours.')
                 self.speed_status = UpdateSpeed.NIGHT
@@ -517,7 +507,6 @@ class HusqvarnaPlugin:
         else:
             configured_interval_minutes = float(Parameters.get('Mode5', '1').replace(',','.'))
             self.run_again = DomoticzConstants.MINUTE * configured_interval_minutes
-            
             if self.speed_status != UpdateSpeed.NORMAL:
                 Domoticz.Status(f'Re-establish normal update speed to {self.run_again/DomoticzConstants.MINUTE} minutes.')
                 self.speed_status = UpdateSpeed.NORMAL
@@ -570,13 +559,10 @@ class HusqvarnaPlugin:
         
         if action == HusqvarnaAction.LOGIN.value:
             self._handle_login_task()
-            
         elif action == HusqvarnaAction.GET_MOWERS.value:
             self._handle_get_mowers_task()
-            
         elif action == HusqvarnaAction.GET_STATUS.value:
             self._handle_get_status_task()
-            
         else:
             self._handle_mower_command_task(task)
 
@@ -640,9 +626,36 @@ class HusqvarnaPlugin:
             mower: Dictionary with mower information
         """
         mower_name = mower['name']
-        
+
+        # Log activity changes with human-readable labels
+        activity = mower.get('activity', '')
+        previous = self.previous_activity.get(mower_name, '')
+        activity_label = ACTIVITY_LOG_MAP.get(activity, activity)
+
+        if activity != previous:
+            if not previous:
+                # First poll after startup - always log current status with friendly label
+                Domoticz.Log(f"Mower {mower_name} startup status: {activity_label}.")
+            elif activity == 'MOWING':
+                Domoticz.Log(f"Mower {mower_name} started mowing.")
+            elif activity == 'LEAVING':
+                Domoticz.Log(f"Mower {mower_name} is leaving the charging station.")
+            elif activity == 'GOING_HOME':
+                Domoticz.Log(f"Mower {mower_name} is going home.")
+            elif activity == 'CHARGING':
+                if previous in ['GOING_HOME', 'MOWING', 'LEAVING']:
+                    Domoticz.Log(f"Mower {mower_name} returned to charging station.")
+            elif activity == 'PARKED_IN_CS':
+                if previous in ['GOING_HOME', 'MOWING', 'LEAVING', 'CHARGING']:
+                    Domoticz.Log(f"Mower {mower_name} is parked in charging station.")
+            elif activity == 'STOPPED_IN_GARDEN':
+                Domoticz.Log(f"Mower {mower_name} stopped in garden.")
+
+        self.previous_activity[mower_name] = activity
+
         # Create any missing devices (handles new devices added in later versions)
         self._create_missing_devices(mower_name)
+
         # Determine image based on mower state
         image = Images[ImageIdentifier.OFF.value].ID if mower.get('state') == 'OFF' else Images[ImageIdentifier.STANDARD.value].ID
         
@@ -732,26 +745,35 @@ class HusqvarnaPlugin:
             return f"{base}\n<body><p style=\"line-height:80%;font-size:80%;\">{error_state.strip()}</p></body>"
 
         elif activity_str is None:
-            # NOT_APPLICABLE — toon alleen de state
+            # NOT_APPLICABLE â€” show state only, with optional restriction
             if restricted_str:
                 return f'{state_str}: {restricted_str}'
             return state_str
 
         elif activity_str:
             if state == 'RESTRICTED':
-                # Toon alleen activiteit, met optionele reden
+                # Show activity only, without "Restricted:" prefix
                 if restricted_str:
                     return f'{activity_str} ({restricted_str})'
-                return activity_str  # Geen "Restricted:" prefix
+                return activity_str
             return f'{state_str}: {activity_str}'
+
+        return state_str
 
     def _determine_mower_zone(self, mower: Dict[str, Any]) -> str:
         """Determine the garden zone where the mower is located."""
         location_data = mower.get('location')
         if location_data and location_data.get('latitude') is not None and location_data.get('longitude') is not None:
             return self._find_nearest_zone({'latitude': location_data['latitude'], 'longitude': location_data['longitude']})
-        else:
-            return "Unknown"
+
+        # Geen GPS beschikbaar - gebruik de eerste zone uit de configuratie als fallback
+        if self.config.zones:
+            fallback_zone = self.config.zones[0]
+            if isinstance(fallback_zone, dict) and 'name' in fallback_zone:
+                Domoticz.Debug(f"No GPS available, using fallback zone: {fallback_zone['name']}")
+                return fallback_zone['name']
+
+        return 'Unknown'
 
     def _find_nearest_zone(self, position: Dict[str, float]) -> str:
         """Find the nearest zone based on GPS coordinates."""
@@ -797,7 +819,6 @@ class HusqvarnaPlugin:
             return 'No schedule'
 
         try:
-            # Convert milliseconds UTC timestamp to local datetime
             slot_dt = datetime.datetime.fromtimestamp(timestamp_ms / 1000)
             now = datetime.datetime.now()
 
@@ -810,7 +831,6 @@ class HusqvarnaPlugin:
 
             result = f'{day_label} {slot_dt.strftime("%H:%M")}'
 
-            # Add restriction reason if present and relevant
             if restricted_reason and restricted_reason != 'NONE':
                 reason_map = {
                     'WEEK_SCHEDULE':            'scheduled',
@@ -985,22 +1005,16 @@ class HusqvarnaPlugin:
         try:
             if action == HusqvarnaAction.START.value:
                 status = self.husqvarna_api.action_Start(mower_name, duration=1440)
-                    
             elif action == HusqvarnaAction.START_6H.value:
                 status = self.husqvarna_api.action_Start(mower_name, duration=360)
-                    
             elif action == HusqvarnaAction.PARK_UNTIL_FURTHER_NOTICE.value:
                 status = self.husqvarna_api.action_ParkUntilFurtherNotice(mower_name)
-                    
             elif action == HusqvarnaAction.PARK_UNTIL_NEXT_SCHEDULE.value:
                 status = self.husqvarna_api.action_ParkUntilNextSchedule(mower_name)
-                    
             elif action == HusqvarnaAction.PAUSE.value:
                 status = self.husqvarna_api.action_Pause(mower_name)
-                    
             elif action == HusqvarnaAction.RESUME_SCHEDULE.value:
                 status = self.husqvarna_api.action_ResumeSchedule(mower_name)
-                    
             elif action == HusqvarnaAction.SET_CUTTING_HEIGHT.value:
                 cutting_height = task.get('Cutting_height')
                 if cutting_height is not None:

--- a/plugin.py
+++ b/plugin.py
@@ -8,7 +8,7 @@ It provides monitoring of mower status, battery level, location, and control fun
 start/stop, parking, and cutting height adjustment.
 
 Author: Filip Demaertelaere
-Version: 2.0.0
+Version: 2.1.0
 """
 
 # Standard imports
@@ -40,9 +40,10 @@ import Husqvarna
 
 # XML plugin configuration
 """
-<plugin key="Husqvarna" name="Husqvarna" author="Filip Demaertelaere" version="2.0.0">
+<plugin key="Husqvarna" name="Husqvarna" author="Filip Demaertelaere" version="2.1.0">
     <description>
         <h2>Husqvarna</h2>
+        <p>Version 2.1.0</p>
         <p>The Husqvarna plugin for Domoticz provides seamless integration with your Husqvarna robotic lawnmowers. Leveraging the official Husqvarna API, this plugin allows you to monitor your mower's status and control key functions directly from your Domoticz environment. It creates virtual devices for each connected mower, offering real-time insights into its activity, battery level, cutting height, and precise location.</p>
         <br/>
         <h2>Key features:</h2>
@@ -640,10 +641,8 @@ class HusqvarnaPlugin:
         """
         mower_name = mower['name']
         
-        # Create devices if they don't exist
-        if not Devices.get(mower_name, None):
-            self._create_mower_devices(mower_name)
-        
+        # Create any missing devices (handles new devices added in later versions)
+        self._create_missing_devices(mower_name)
         # Determine image based on mower state
         image = Images[ImageIdentifier.OFF.value].ID if mower.get('state') == 'OFF' else Images[ImageIdentifier.STANDARD.value].ID
         
@@ -678,17 +677,73 @@ class HusqvarnaPlugin:
 
     def _format_state_text(self, mower: Dict[str, Any]) -> str:
         """Format the state text based on mower state, activity, and error."""
+
+        STATE_MAP = {
+            'OFF':              'Off',
+            'WAIT_UPDATING':    'Updating firmware',
+            'WAIT_POWER_UP':    'Starting up',
+            'OK':               'OK',
+            'ERROR':            'Error',
+            'ERROR_AT_POWER_UP':'Error at startup',
+            'FATAL_ERROR':      'Fatal error',
+            'RESTRICTED':       'Restricted',
+            'PAUSED':           'Paused',
+            'IN_OPERATION':     'In operation',
+            'STOPPED':          'Stopped',
+        }
+
+        ACTIVITY_MAP = {
+            'UNKNOWN':                  'Unknown',
+            'NOT_APPLICABLE':           None,
+            'MOWING':                   'Mowing',
+            'GOING_HOME':               'Going home',
+            'CHARGING':                 'Charging',
+            'LEAVING':                  'Leaving',
+            'PARKED_IN_CS':             'Parked in charging station',
+            'STOPPED_IN_GARDEN':        'Stopped in garden',
+            'CUTTING_NOT_POSSIBLE':     'Cutting not possible',
+        }
+
+        RESTRICTED_MAP = {
+            'NONE':                     None,
+            'WEEK_SCHEDULE':            None,
+            'PARK_OVERRIDE':            'Parked (override)',
+            'SENSOR':                   'Sensor restriction',
+            'DAILY_LIMIT':              'Daily limit reached',
+            'FOTA':                     'Firmware update',
+            'FROST':                    'Frost protection',
+            'ALL_WORK_AREAS_COMPLETED': 'All areas completed',
+            'EXTERNAL':                 'External restriction',
+        }
+
         error_state = mower.get('error_state')
-        state = mower.get('state')
-        activity = mower.get('activity')
+        state = mower.get('state', '')
+        activity = mower.get('activity', '')
+        restricted_reason = mower.get('restricted_reason', '')
+
+        state_str = STATE_MAP.get(state, state)
+        activity_str = ACTIVITY_MAP.get(activity, activity)
+        restricted_str = RESTRICTED_MAP.get(restricted_reason, restricted_reason) if restricted_reason else None
 
         if error_state:
-            activity_str = f": {activity}" if activity and activity != 'NOT_APPLICABLE' else ""
-            return f"{state}{activity_str}\n<body><p style=\"line-height:80%;font-size:80%;\">{error_state.strip()}</p></body>"
-        elif activity == 'NOT_APPLICABLE':
-            return f"{state}"
-        else:
-            return f"{state}: {activity}"
+            base = state_str
+            if activity_str:
+                base += f': {activity_str}'
+            return f"{base}\n<body><p style=\"line-height:80%;font-size:80%;\">{error_state.strip()}</p></body>"
+
+        elif activity_str is None:
+            # NOT_APPLICABLE — toon alleen de state
+            if restricted_str:
+                return f'{state_str}: {restricted_str}'
+            return state_str
+
+        elif activity_str:
+            if state == 'RESTRICTED':
+                # Toon alleen activiteit, met optionele reden
+                if restricted_str:
+                    return f'{activity_str} ({restricted_str})'
+                return activity_str  # Geen "Restricted:" prefix
+            return f'{state_str}: {activity_str}'
 
     def _determine_mower_zone(self, mower: Dict[str, Any]) -> str:
         """Determine the garden zone where the mower is located."""
@@ -775,86 +830,98 @@ class HusqvarnaPlugin:
             Domoticz.Debug(f"Error formatting schedule text: {e}")
             return 'No schedule'
 
+    def _create_missing_devices(self, mower_name: str) -> None:
+        """
+        Create any missing Domoticz devices for a mower.
+        This allows adding new device types without requiring deletion of existing ones.
+        """
+        existing_units = set()
+        if Devices.get(mower_name):
+            existing_units = {unit for unit in Devices[mower_name].Units}
+
+        if UnitId.STATE not in existing_units:
+            Domoticz.Unit(
+                DeviceID=mower_name,
+                Unit=UnitId.STATE,
+                Name=f"{Parameters['Name']} - {mower_name} - {DeviceText.STATE.value}",
+                TypeName='Text',
+                Image=Images[ImageIdentifier.STANDARD.value].ID,
+                Used=1
+            ).Create()
+
+        if UnitId.RUN not in existing_units:
+            Domoticz.Unit(
+                DeviceID=mower_name,
+                Unit=UnitId.RUN,
+                Name=f"{Parameters['Name']} - {mower_name} - {DeviceText.RUN.value}",
+                Type=244,
+                Subtype=73,
+                Switchtype=0,
+                Image=Images[ImageIdentifier.STANDARD.value].ID,
+                Used=1
+            ).Create()
+
+        if UnitId.BATTERY not in existing_units:
+            Domoticz.Unit(
+                DeviceID=mower_name,
+                Unit=UnitId.BATTERY,
+                Name=f"{Parameters['Name']} - {mower_name} - {DeviceText.BATTERY.value}",
+                TypeName='Custom',
+                Options={'Custom': '0;%'},
+                Image=Images[ImageIdentifier.STANDARD.value].ID,
+                Used=0
+            ).Create()
+
+        if UnitId.LOCATION not in existing_units:
+            Domoticz.Unit(
+                DeviceID=mower_name,
+                Unit=UnitId.LOCATION,
+                Name=f"{Parameters['Name']} - {mower_name} - {DeviceText.LOCATION.value}",
+                TypeName='Text',
+                Image=Images[ImageIdentifier.STANDARD.value].ID,
+                Used=1
+            ).Create()
+
+        if UnitId.CUTTING not in existing_units:
+            self._create_cutting_height_selector(mower_name)
+
+        if UnitId.ACTIONS not in existing_units:
+            actions = f"|{HusqvarnaAction.START_6H.value}|{HusqvarnaAction.PAUSE.value}|{HusqvarnaAction.RESUME_SCHEDULE.value}|{HusqvarnaAction.PARK_UNTIL_FURTHER_NOTICE.value}|{HusqvarnaAction.PARK_UNTIL_NEXT_SCHEDULE.value}"
+            Domoticz.Unit(
+                DeviceID=mower_name,
+                Unit=UnitId.ACTIONS,
+                Name=f"{Parameters['Name']} - {mower_name} - {DeviceText.ACTIONS.value}",
+                TypeName='Selector Switch',
+                Options={
+                    'LevelActions': '|'*actions.count('|'),
+                    'LevelNames': actions,
+                    'LevelOffHidden': 'false',
+                    'SelectorStyle': '1'
+                },
+                Image=Images[ImageIdentifier.STANDARD.value].ID,
+                Used=1
+            ).Create()
+
+        if UnitId.SCHEDULE not in existing_units:
+            Domoticz.Unit(
+                DeviceID=mower_name,
+                Unit=UnitId.SCHEDULE,
+                Name=f"{Parameters['Name']} - {mower_name} - {DeviceText.SCHEDULE.value}",
+                TypeName='Text',
+                Image=Images[ImageIdentifier.STANDARD.value].ID,
+                Used=1
+            ).Create()
+
+        Domoticz.Debug(f"Device check complete for mower '{mower_name}'. Existing units: {existing_units}")
+
     def _create_mower_devices(self, mower_name: str) -> None:
         """
-        Create Domoticz devices for a mower.
+        Create all Domoticz devices for a new mower.
+        Delegates to _create_missing_devices and sets initial timeout.
         Args:
             mower_name: Name of the mower
         """
-        # State text display
-        Domoticz.Unit(
-            DeviceID=mower_name, 
-            Unit=UnitId.STATE, 
-            Name=f"{Parameters['Name']} - {mower_name} - {DeviceText.STATE.value}", 
-            TypeName='Text', 
-            Image=Images[ImageIdentifier.STANDARD.value].ID, 
-            Used=1
-        ).Create()
-        
-        # Run (On/Off) switch
-        Domoticz.Unit(
-            DeviceID=mower_name, 
-            Unit=UnitId.RUN, 
-            Name=f"{Parameters['Name']} - {mower_name} - {DeviceText.RUN.value}", 
-            Type=244, 
-            Subtype=73, 
-            Switchtype=0, 
-            Image=Images[ImageIdentifier.STANDARD.value].ID, 
-            Used=1
-        ).Create()
-        
-        # Battery level
-        Domoticz.Unit(
-            DeviceID=mower_name, 
-            Unit=UnitId.BATTERY, 
-            Name=f"{Parameters['Name']} - {mower_name} - {DeviceText.BATTERY.value}", 
-            TypeName='Custom', 
-            Options={'Custom': '0;%'}, 
-            Image=Images[ImageIdentifier.STANDARD.value].ID, 
-            Used=0
-        ).Create()
-        
-        # Location in garden
-        Domoticz.Unit(
-            DeviceID=mower_name, 
-            Unit=UnitId.LOCATION, 
-            Name=f"{Parameters['Name']} - {mower_name} - {DeviceText.LOCATION.value}", 
-            TypeName='Text', 
-            Image=Images[ImageIdentifier.STANDARD.value].ID, 
-            Used=1
-        ).Create()
-        
-        # Cutting height selector
-        self._create_cutting_height_selector(mower_name)
-        
-        # Actions selector
-        actions = f"|{HusqvarnaAction.START_6H.value}|{HusqvarnaAction.PAUSE.value}|{HusqvarnaAction.RESUME_SCHEDULE.value}|{HusqvarnaAction.PARK_UNTIL_FURTHER_NOTICE.value}|{HusqvarnaAction.PARK_UNTIL_NEXT_SCHEDULE.value}"
-        Domoticz.Unit(
-            DeviceID=mower_name, 
-            Unit=UnitId.ACTIONS, 
-            Name=f"{Parameters['Name']} - {mower_name} - {DeviceText.ACTIONS.value}", 
-            TypeName='Selector Switch', 
-            Options={
-                'LevelActions': '|'*actions.count('|'), 
-                'LevelNames': actions, 
-                'LevelOffHidden': 'false', 
-                'SelectorStyle': '1'
-            }, 
-            Image=Images[ImageIdentifier.STANDARD.value].ID, 
-            Used=1
-        ).Create()
-
-        # Next schedule display
-        Domoticz.Unit(
-            DeviceID=mower_name,
-            Unit=UnitId.SCHEDULE,
-            Name=f"{Parameters['Name']} - {mower_name} - {DeviceText.SCHEDULE.value}",
-            TypeName='Text',
-            Image=Images[ImageIdentifier.STANDARD.value].ID,
-            Used=1
-        ).Create()
-        
-        # Set all devices as timed out until we get real data
+        self._create_missing_devices(mower_name)
         timeout_device(Devices, device_id=mower_name)
 
     def _create_cutting_height_selector(self, mower_name: str) -> None:

--- a/plugin.py
+++ b/plugin.py
@@ -52,6 +52,7 @@ import Husqvarna
             <li><b>Location Tracking:</b> Based on GPS coordinates of your mower, with an option to display its proximity to predefined zones (e.g., "Front Garden", "Back Garden").</li>
             <li><b>Remote Control Actions:</b> Start mowing, pause operations, resume schedules, or park the mower (until further notice or next schedule).</li>
             <li><b>Cutting Height Adjustment:</b> Remotely set the cutting height of your mower.</li>
+            <li><b>Next Schedule:</b> Shows the next upcoming scheduled mowing session.</li>
             <li><b>Zone Management:</b> Define custom zones for your property to get distance information and easily identify which zone your mower is currently in.</li>
         </ul>
         <br/>
@@ -105,6 +106,7 @@ class UnitId(IntEnum):
     ACTIONS = 4
     LOCATION = 5
     CUTTING = 6
+    SCHEDULE = 7  # Next scheduled mowing session
 
 class DeviceText(str, Enum):
     """Text identifiers for device names."""
@@ -114,6 +116,7 @@ class DeviceText(str, Enum):
     ACTIONS = 'Actions'
     LOCATION = 'Location'
     CUTTING = 'Cutting Height (cm)'
+    SCHEDULE = 'Next Schedule'
 
 class ImageIdentifier(str, Enum):
     """Custom image identifiers for Husqvarna mower devices."""
@@ -265,7 +268,7 @@ class HusqvarnaPlugin:
         
         # Wait for thread to exit
         if self.tasks_thread and self.tasks_thread.is_alive():
-            self.tasks_thread.join(timeout=10) # Added timeout for graceful shutdown
+            self.tasks_thread.join(timeout=10)
 
         # Wait until queue thread has exited
         Domoticz.Debug(f'Threads still active: {threading.active_count()} (should be 1)')
@@ -350,7 +353,7 @@ class HusqvarnaPlugin:
                 self.tasks_queue.put({'Action': HusqvarnaAction.START.value, 'Mower_name': mower['name']})
         else: # Command is 'Off'
             exec_state.action = HusqvarnaAction.PARK_UNTIL_FURTHER_NOTICE.value
-            exec_state.status = ExecutionStatus.INITIATED # Set status for the park command
+            exec_state.status = ExecutionStatus.INITIATED
             exec_state.command_data.clear()
             exec_state.retries = 0
             update_device(False, Devices, device_id, UnitId.RUN, 0, 0)
@@ -360,7 +363,7 @@ class HusqvarnaPlugin:
         """Handle commands for cutting height adjustment."""
         exec_state = self.execution_status[device_id]
         exec_state.action = HusqvarnaAction.SET_CUTTING_HEIGHT.value
-        exec_state.status = ExecutionStatus.INITIATED.value
+        exec_state.status = ExecutionStatus.INITIATED
         exec_state.command_data.clear()
         exec_state.retries = 0
         
@@ -372,7 +375,7 @@ class HusqvarnaPlugin:
             'Mower_name': mower['name'], 
             'Cutting_height': cutting_height
         })
-        exec_state.command_data['Cutting_height'] = cutting_height # Store for retry if needed
+        exec_state.command_data['Cutting_height'] = cutting_height
 
     def _handle_action_command(self, device_id: str, mower: Dict[str, Any], level: int) -> None:
         """Handle commands from the Actions selector switch."""
@@ -427,9 +430,8 @@ class HusqvarnaPlugin:
             
             # Refresh mower list daily
             now = datetime.datetime.now()
-            # Ensure husqvarna_api and its method exist before calling
             if (self.husqvarna_api and 
-                self.husqvarna_api.get_timestamp_last_update_mower_list() and # Check if timestamp is available
+                self.husqvarna_api.get_timestamp_last_update_mower_list() and
                 self.husqvarna_api.get_timestamp_last_update_mower_list() + datetime.timedelta(days=1) < now):
                 self.tasks_queue.put({'Action': HusqvarnaAction.GET_MOWERS.value})
                 
@@ -454,12 +456,11 @@ class HusqvarnaPlugin:
                 exec_state = self.execution_status[mower_name]
                 if exec_state.status == ExecutionStatus.ERROR and exec_state.retries < 2:
                     Domoticz.Status(f"Retry {exec_state.retries + 1} for Husqvarna mower {mower_name} to launch command {exec_state.action}")
-                    exec_state.status = ExecutionStatus.INITIATED # Reset status to initiated for retry
+                    exec_state.status = ExecutionStatus.INITIATED
                     exec_state.retries += 1
                     
                     if exec_state.action:
                         task_to_retry = {'Action': exec_state.action, 'Mower_name': mower_name}
-                        # Re-add command-specific data if it exists
                         if exec_state.action == HusqvarnaAction.SET_CUTTING_HEIGHT.value and 'Cutting_height' in exec_state.command_data:
                             task_to_retry['Cutting_height'] = exec_state.command_data['Cutting_height']
                         self.tasks_queue.put(task_to_retry)
@@ -479,7 +480,6 @@ class HusqvarnaPlugin:
         hours = now.hour
         
         if self.system_retries > 5:
-            # Too many errors from Husqvarna server received
             configured_interval_minutes = float(Parameters.get('Mode5', '1').replace(',','.'))
             self.run_again = min(12*60*DomoticzConstants.MINUTE, self.system_retries*DomoticzConstants.MINUTE*configured_interval_minutes)
 
@@ -488,7 +488,6 @@ class HusqvarnaPlugin:
                 self.speed_status = UpdateSpeed.SYSTEM_ERROR
 
         elif self.husqvarna_api and self.husqvarna_api.are_api_limits_reached():
-            # API limits reached - slow down significantly
             self.run_again = max(60 * DomoticzConstants.MINUTE, self.run_again)
             
             if self.speed_status != UpdateSpeed.LIMITS_EXCEEDED:
@@ -496,21 +495,18 @@ class HusqvarnaPlugin:
                 self.speed_status = UpdateSpeed.LIMITS_EXCEEDED
                 
         elif self.husqvarna_api and self.husqvarna_api.are_all_mowers_off():
-            # All mowers off - check once per hour
             self.run_again = 60 * DomoticzConstants.MINUTE
             
             if self.speed_status != UpdateSpeed.ALL_OFF:
                 Domoticz.Status(f'Reduce status update speed to {self.run_again/DomoticzConstants.MINUTE} minutes as all Husqvarna mowers are off.')
                 self.speed_status = UpdateSpeed.ALL_OFF
 
-        elif self.husqvarna_api and any(m.get('activity', '') == 'GOING_HOME' for m in self.husqvarna_api.mowers if isinstance(m, dict)): # Added type check for 'm'
+        elif self.husqvarna_api and any(m.get('activity', '') == 'GOING_HOME' for m in self.husqvarna_api.mowers if isinstance(m, dict)):
             configured_interval_minutes = float(Parameters.get('Mode5', '1').replace(',','.'))
             self.run_again = DomoticzConstants.MINUTE * configured_interval_minutes / 2
-            # No specific speed_status change for this, it's a temporary boost
             Domoticz.Debug(f"Increasing update speed to {self.run_again / DomoticzConstants.MINUTE} minutes as a mower is going home.")
         
         elif hours >= 22 or hours <= 5:
-            # Night time - reduced polling (every 3 hours)
             self.run_again = DomoticzConstants.MINUTE * 180
             
             if self.speed_status != UpdateSpeed.NIGHT:
@@ -518,7 +514,6 @@ class HusqvarnaPlugin:
                 self.speed_status = UpdateSpeed.NIGHT
                 
         else:
-            # Normal daytime operation - use configured interval
             configured_interval_minutes = float(Parameters.get('Mode5', '1').replace(',','.'))
             self.run_again = DomoticzConstants.MINUTE * configured_interval_minutes
             
@@ -533,13 +528,12 @@ class HusqvarnaPlugin:
         during potentially slow API operations.
         """
         Domoticz.Debug('Entering tasks handler')
+        task = None
             
         while True:
             try:
-                # Get task from queue (blocking)
                 task = self.tasks_queue.get(block=True)
                     
-                # Exit signal received
                 if task is None:
                     Domoticz.Debug('Exiting task handler')
                     try:
@@ -551,20 +545,19 @@ class HusqvarnaPlugin:
                     self.tasks_queue.task_done()
                     break
                         
-                # Process the task
                 Domoticz.Debug(f"Handling task: {task['Action']}.")
                 self._process_task(task)
                     
             except queue.Empty:
-                pass # Continue loop if queue is empty 
+                pass
             except Exception as e:
                 Domoticz.Error(f"Unexpected error in task handler: {e}")
                 log_backtrace_error(Parameters)
                    
             finally:
-                # Mark task as done
-                if 'task' in locals():
+                if task is not None:
                     self.tasks_queue.task_done()
+                    task = None
 
     def _process_task(self, task: Dict[str, Any]) -> None:
         """
@@ -574,32 +567,33 @@ class HusqvarnaPlugin:
         """
         action = task['Action']
         
-        # Handle login
         if action == HusqvarnaAction.LOGIN.value:
             self._handle_login_task()
             
-        # Handle mower list retrieval
         elif action == HusqvarnaAction.GET_MOWERS.value:
             self._handle_get_mowers_task()
             
-        # Handle status update
         elif action == HusqvarnaAction.GET_STATUS.value:
             self._handle_get_status_task()
             
-        # Handle mower commands
         else:
             self._handle_mower_command_task(task)
 
     def _handle_login_task(self) -> None:
-        """Handle API login task."""
-        # Ensure Husqvarna instance is re-created on each login attempt for fresh state if needed
-        self.husqvarna_api = Husqvarna.Husqvarna(Parameters['Mode1'], Parameters['Mode2'])
-        if self.husqvarna_api:
+        """
+        Handle API login task.
+        Uses bool(api) which calls __bool__ on the Husqvarna object,
+        which returns self.state.authenticated set during __init__.
+        """
+        api = Husqvarna.Husqvarna(Parameters['Mode1'], Parameters['Mode2'])
+        if bool(api):
+            self.husqvarna_api = api
             self.system_retries = 0
             Domoticz.Debug("Successfully logged in to Husqvarna API.")
         else:
-            error = self.husqvarna_api.get_http_error() if self.husqvarna_api is not None else 'Unknown'
+            error = api.get_http_error() if api is not None else 'Unknown'
             Domoticz.Error(f"Unable to get credentials from Husqvarna Cloud: {error}")
+            self.husqvarna_api = None
             self.system_retries += 1
             timeout_device(Devices)
 
@@ -609,8 +603,14 @@ class HusqvarnaPlugin:
             if self.husqvarna_api.get_mowers():
                 self.system_retries = 0
                 for mower in self.husqvarna_api.mowers:
-                    if mower['name'] not in self.execution_status: # Initialize only if not present
+                    if mower['name'] not in self.execution_status:
                         self.execution_status[mower['name']] = ExecutionState()
+                # Clean up execution_status entries for mowers no longer present
+                current_names = {m['name'] for m in self.husqvarna_api.mowers}
+                stale_names = [n for n in self.execution_status if n not in current_names]
+                for name in stale_names:
+                    del self.execution_status[name]
+                    Domoticz.Debug(f"Removed stale execution status for mower '{name}'.")
             else:
                 Domoticz.Error(f"Error getting list of mowers from Husqvarna Cloud: {self.husqvarna_api.get_http_error()}")
                 self.system_retries += 1
@@ -672,6 +672,10 @@ class HusqvarnaPlugin:
         action_image = Images[ImageIdentifier.OFF.value].ID if mower['state'] == 'OFF' else Images[ImageIdentifier.INVERSE.value].ID
         update_device(True, Devices, mower_name, UnitId.ACTIONS, 2, 0, Image=action_image)
 
+        # Update next schedule
+        schedule_text = self._format_schedule_text(mower)
+        update_device(False, Devices, mower_name, UnitId.SCHEDULE, 0, schedule_text, Image=image)
+
     def _format_state_text(self, mower: Dict[str, Any]) -> str:
         """Format the state text based on mower state, activity, and error."""
         error_state = mower.get('error_state')
@@ -679,9 +683,8 @@ class HusqvarnaPlugin:
         activity = mower.get('activity')
 
         if error_state:
-            # Ensure proper handling of potentially None or empty activity
             activity_str = f": {activity}" if activity and activity != 'NOT_APPLICABLE' else ""
-            return f"{state}: {activity_str}\n<body><p style=\"line-height:80%;font-size:80%;\">{error_state.strip()}</p></body>"
+            return f"{state}{activity_str}\n<body><p style=\"line-height:80%;font-size:80%;\">{error_state.strip()}</p></body>"
         elif activity == 'NOT_APPLICABLE':
             return f"{state}"
         else:
@@ -691,10 +694,8 @@ class HusqvarnaPlugin:
         """Determine the garden zone where the mower is located."""
         location_data = mower.get('location')
         if location_data and location_data.get('latitude') is not None and location_data.get('longitude') is not None:
-            # Pass only the necessary parts of location to _find_nearest_zone
             return self._find_nearest_zone({'latitude': location_data['latitude'], 'longitude': location_data['longitude']})
         else:
-            # Return current device s_value if no valid location, or "Unknown"
             return "Unknown"
 
     def _find_nearest_zone(self, position: Dict[str, float]) -> str:
@@ -706,7 +707,6 @@ class HusqvarnaPlugin:
             return "Unknown"
             
         try:
-            # Filter for valid zones before sorting
             valid_zones = [
                 z for z in self.config.zones 
                 if isinstance(z, dict) and 'latitude' in z and 'longitude' in z and 
@@ -729,6 +729,51 @@ class HusqvarnaPlugin:
         except Exception as e:
             Domoticz.Debug(f"Error finding nearest zone: {e}")
             return "Unknown"
+
+    def _format_schedule_text(self, mower: Dict[str, Any]) -> str:
+        """
+        Format the next scheduled mowing session as readable text.
+        Uses nextStartTimestamp from the Husqvarna planner API (milliseconds UTC).
+        """
+        timestamp_ms = mower.get('next_start_timestamp')
+        restricted_reason = mower.get('restricted_reason')
+
+        if not timestamp_ms:
+            return 'No schedule'
+
+        try:
+            # Convert milliseconds UTC timestamp to local datetime
+            slot_dt = datetime.datetime.fromtimestamp(timestamp_ms / 1000)
+            now = datetime.datetime.now()
+
+            if slot_dt.date() == now.date():
+                day_label = 'Today'
+            elif slot_dt.date() == (now + datetime.timedelta(days=1)).date():
+                day_label = 'Tomorrow'
+            else:
+                day_label = slot_dt.strftime('%A')
+
+            result = f'{day_label} {slot_dt.strftime("%H:%M")}'
+
+            # Add restriction reason if present and relevant
+            if restricted_reason and restricted_reason != 'NONE':
+                reason_map = {
+                    'WEEK_SCHEDULE':            'scheduled',
+                    'PARK_OVERRIDE':            'parked (override)',
+                    'SENSOR':                   'sensor restriction',
+                    'DAILY_LIMIT':              'daily limit reached',
+                    'FOTA':                     'firmware update',
+                    'FROST':                    'frost protection',
+                    'ALL_WORK_AREAS_COMPLETED': 'all areas done',
+                }
+                reason_text = reason_map.get(restricted_reason, restricted_reason)
+                result += f' ({reason_text})'
+
+            return result
+
+        except Exception as e:
+            Domoticz.Debug(f"Error formatting schedule text: {e}")
+            return 'No schedule'
 
     def _create_mower_devices(self, mower_name: str) -> None:
         """
@@ -798,13 +843,22 @@ class HusqvarnaPlugin:
             Image=Images[ImageIdentifier.STANDARD.value].ID, 
             Used=1
         ).Create()
+
+        # Next schedule display
+        Domoticz.Unit(
+            DeviceID=mower_name,
+            Unit=UnitId.SCHEDULE,
+            Name=f"{Parameters['Name']} - {mower_name} - {DeviceText.SCHEDULE.value}",
+            TypeName='Text',
+            Image=Images[ImageIdentifier.STANDARD.value].ID,
+            Used=1
+        ).Create()
         
         # Set all devices as timed out until we get real data
         timeout_device(Devices, device_id=mower_name)
 
     def _create_cutting_height_selector(self, mower_name: str) -> None:
         """Create the cutting height selector with proper range."""
-        # Use configured height range if available
         min_height = self.config.height_min_max.get('min')
         max_height = self.config.height_min_max.get('max')
         steps = self.config.height_min_max.get('steps')
@@ -813,8 +867,8 @@ class HusqvarnaPlugin:
             if steps > 1:
                 height_interval = (max_height - min_height) / (steps - 1)
                 height_range = [min_height + i * height_interval for i in range(steps)]
-            else: # Handle case with 1 step to avoid division by zero if interval is calculated
-                height_range = [min_height] # Only one value
+            else:
+                height_range = [min_height]
 
             level_names = '|'.join(f'{height:.1f}' for height in height_range)
                 
@@ -856,39 +910,30 @@ class HusqvarnaPlugin:
             Domoticz.Debug(f"Mower {mower_name} is switched off. Action {action} will not be executed.")
             return
             
-        # Initialize execution status tracking if not exists
         if mower_name not in self.execution_status:
             self.execution_status[mower_name] = ExecutionState()
             
-        # Execute the command based on action type
         status = None
         
         try:
-            # Start mowing (24 hours)
             if action == HusqvarnaAction.START.value:
                 status = self.husqvarna_api.action_Start(mower_name, duration=1440)
                     
-            # Start mowing (6 hours)
             elif action == HusqvarnaAction.START_6H.value:
                 status = self.husqvarna_api.action_Start(mower_name, duration=360)
                     
-            # Park until further notice
             elif action == HusqvarnaAction.PARK_UNTIL_FURTHER_NOTICE.value:
                 status = self.husqvarna_api.action_ParkUntilFurtherNotice(mower_name)
                     
-            # Park until next schedule
             elif action == HusqvarnaAction.PARK_UNTIL_NEXT_SCHEDULE.value:
                 status = self.husqvarna_api.action_ParkUntilNextSchedule(mower_name)
                     
-            # Pause mowing
             elif action == HusqvarnaAction.PAUSE.value:
                 status = self.husqvarna_api.action_Pause(mower_name)
                     
-            # Resume schedule
             elif action == HusqvarnaAction.RESUME_SCHEDULE.value:
                 status = self.husqvarna_api.action_ResumeSchedule(mower_name)
                     
-            # Set cutting height
             elif action == HusqvarnaAction.SET_CUTTING_HEIGHT.value:
                 cutting_height = task.get('Cutting_height')
                 if cutting_height is not None:
@@ -896,7 +941,6 @@ class HusqvarnaPlugin:
                 else:
                     Domoticz.Debug(f"Missing cutting height value for {mower_name}")
             
-            # Update status based on command result
             if status is None:
                 Domoticz.Error(f"Unknown action code {action}")
             elif status:
@@ -906,7 +950,6 @@ class HusqvarnaPlugin:
                 timeout_device(Devices, device_id=mower_name)
                 self.execution_status[mower_name].status = ExecutionStatus.ERROR
                 
-            # Request quick status update after command
             self.run_again = DomoticzConstants.MINUTE / 2
                 
         except Exception as e:


### PR DESCRIPTION
## New Features

### Next Schedule device (Unit 7)
- Added new Text device per mower showing the next planned mowing session
- Uses `nextStartTimestamp` from the Husqvarna planner API (milliseconds UTC)
- Displays human-readable label: 'Today', 'Tomorrow', or weekday name + time
- Includes restriction reason (e.g. 'scheduled', 'frost protection', 'parked (override)')
- Falls back to 'No schedule' if no timestamp is available

### Auto-creation of missing devices
- Added `_create_missing_devices()` method that checks each unit individually
- Missing devices are now created automatically on next poll without requiring
  deletion of existing devices
- `_create_mower_devices()` simplified to delegate to `_create_missing_devices()`
- Allows adding new device types in future versions without manual intervention

## Improvements

### State device readability
- Added human-readable translation maps for mower states, activities and
  restricted reasons
- Examples:
    - `RESTRICTED: PARKED_IN_CS` → `Parked in charging station (Week schedule)`
    - `IN_OPERATION: GOING_HOME` → `In operation: Going home`
    - `OFF`                      → `Off`
- Restricted reason is now shown inline with the activity for RESTRICTED state

## Bug Fixes

- Fixed `_handle_cutting_height_command`: `ExecutionStatus.INITIATED.value`
  corrected to `ExecutionStatus.INITIATED`
- Fixed `_handle_login_task`: authentication check now correctly uses `bool(api)`
  which calls `__bool__` on the Husqvarna object instead of the non-existent
  `is_authenticated()` method
- Fixed `_format_state_text`: removed duplicate `:` in error state formatting
- Fixed `_handle_tasks` finally-block: `task_done()` now reliable without
  depending on `locals()`

## Husqvarna.py Changes

- Added `next_start_timestamp` and `restricted_reason` fields to mower data
  in `_get_mower_detailed_info()`, sourced from the `planner` API response
- Removed tasks-based schedule parsing (not returned by the API)